### PR TITLE
Write tests for authentication-service implementations #32

### DIFF
--- a/authentication-service/src/main/java/org/energycompany/controller/AuthenticationController.java
+++ b/authentication-service/src/main/java/org/energycompany/controller/AuthenticationController.java
@@ -37,7 +37,6 @@ public class AuthenticationController {
         return CustomResponse.SUCCESS;
     }
 
-
     @PostMapping("/login")
     public CustomResponse<TokenResponse> loginCustomer(@RequestBody @Valid LoginRequest loginRequest) {
 

--- a/authentication-service/src/main/java/org/energycompany/service/LogoutService.java
+++ b/authentication-service/src/main/java/org/energycompany/service/LogoutService.java
@@ -2,6 +2,7 @@ package org.energycompany.service;
 
 import lombok.RequiredArgsConstructor;
 import org.energycompany.integration.customer.CustomerServiceClient;
+import org.energycompany.model.CustomResponse;
 import org.energycompany.model.auth.dto.request.TokenInvalidateRequest;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +12,8 @@ public class LogoutService {
 
     private final CustomerServiceClient customerServiceClient;
 
-    public void logout(TokenInvalidateRequest tokenInvalidateRequest) {
+    public CustomResponse<Void> logout(TokenInvalidateRequest tokenInvalidateRequest) {
 
-        customerServiceClient.logout(tokenInvalidateRequest);
+        return customerServiceClient.logout(tokenInvalidateRequest);
     }
 }

--- a/authentication-service/src/test/java/org/energycompany/common/AbstractBaseServiceTest.java
+++ b/authentication-service/src/test/java/org/energycompany/common/AbstractBaseServiceTest.java
@@ -1,0 +1,11 @@
+package org.energycompany.common;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public abstract class AbstractBaseServiceTest {
+}

--- a/authentication-service/src/test/java/org/energycompany/common/BaseIntegrationTest.java
+++ b/authentication-service/src/test/java/org/energycompany/common/BaseIntegrationTest.java
@@ -1,0 +1,29 @@
+package org.energycompany.common;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.energycompany.common.annotations.IntegrationTest;
+import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class BaseIntegrationTest extends IntegrationTest {
+
+    @Rule
+    public final WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration
+            .options()
+            .port(8080)
+            .notifier(new ConsoleNotifier(true)));
+
+    @BeforeEach
+    public void setup() {
+        wireMockRule.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        wireMockRule.resetAll();
+        wireMockRule.stop();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/common/annotations/IntegrationTest.java
+++ b/authentication-service/src/test/java/org/energycompany/common/annotations/IntegrationTest.java
@@ -1,0 +1,29 @@
+package org.energycompany.common.annotations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.energycompany.AuthenticationServiceApplication;
+import org.energycompany.common.initializers.WireMockInitializer;
+import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@Tag("integration")
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {AuthenticationServiceApplication.class}
+)
+@ContextConfiguration(initializers = {
+        WireMockInitializer.class
+})
+@ActiveProfiles({"local", "test"})
+@AutoConfigureMockMvc
+@Commit
+public abstract class IntegrationTest {
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+}

--- a/authentication-service/src/test/java/org/energycompany/common/initializers/WireMockInitializer.java
+++ b/authentication-service/src/test/java/org/energycompany/common/initializers/WireMockInitializer.java
@@ -1,0 +1,29 @@
+package org.energycompany.common.initializers;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class WireMockInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    public static final WireMockServer WIRE_MOCK_SERVER =
+            new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+
+    @Override
+    public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+
+        WIRE_MOCK_SERVER.start();
+
+        TestPropertyValues.of("wiremock.server.port=" + WIRE_MOCK_SERVER.port())
+                .applyTo(configurableApplicationContext.getEnvironment());
+
+        WireMock.configureFor(WIRE_MOCK_SERVER.port());
+
+        WireMock.stubFor(WireMock.get("/actuator/health")
+                .willReturn(ResponseDefinitionBuilder.okForJson("{\"status\":\"UP\"}")));
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/controller/LoginAuthenticationControllerTest.java
+++ b/authentication-service/src/test/java/org/energycompany/controller/LoginAuthenticationControllerTest.java
@@ -1,0 +1,49 @@
+package org.energycompany.controller;
+
+import org.energycompany.common.BaseIntegrationTest;
+import org.energycompany.fixtures.LoginRequestFixtures;
+import org.energycompany.fixtures.TokenResponseFixtures;
+import org.energycompany.model.CustomResponse;
+import org.energycompany.model.auth.dto.request.LoginRequest;
+import org.energycompany.model.auth.dto.response.TokenResponse;
+import org.energycompany.service.CustomerLoginService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LoginAuthenticationControllerTest extends BaseIntegrationTest {
+
+    @MockitoBean
+    private CustomerLoginService customerLoginService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldLoginCustomer() throws Exception {
+
+        LoginRequest loginRequest = LoginRequestFixtures.getLoginRequest();
+        TokenResponse tokenResponse = TokenResponseFixtures.getTokenResponse();
+
+        CustomResponse<TokenResponse> expectedResponse = CustomResponse.successOf(tokenResponse);
+        when(customerLoginService.login(any(LoginRequest.class))).thenReturn(expectedResponse);
+
+        mockMvc.perform(post("/api/v1/authentication/customers/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.response.accessToken").value("newAccessToken"));
+
+        verify(customerLoginService, times(1)).login(any(LoginRequest.class));
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/controller/LogoutAuthenticationControllerTest.java
+++ b/authentication-service/src/test/java/org/energycompany/controller/LogoutAuthenticationControllerTest.java
@@ -1,0 +1,42 @@
+package org.energycompany.controller;
+
+import org.energycompany.common.BaseIntegrationTest;
+import org.energycompany.fixtures.TokenInvalidateRequestFixtures;
+import org.energycompany.model.auth.dto.request.TokenInvalidateRequest;
+import org.energycompany.service.LogoutService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class LogoutAuthenticationControllerTest extends BaseIntegrationTest {
+
+    @MockitoBean
+    private LogoutService logoutService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldCustomerLogout() throws Exception {
+
+        TokenInvalidateRequest tokenInvalidateRequest = TokenInvalidateRequestFixtures.getTokenInvalidateRequest();
+        mockMvc.perform(post("/api/v1/authentication/customers/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenInvalidateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.httpStatus").value("OK"));
+
+        verify(logoutService, times(1)).logout(any(TokenInvalidateRequest.class));
+
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/controller/RefreshTokenAuthenticationControllerTest.java
+++ b/authentication-service/src/test/java/org/energycompany/controller/RefreshTokenAuthenticationControllerTest.java
@@ -1,0 +1,51 @@
+package org.energycompany.controller;
+
+import org.energycompany.common.BaseIntegrationTest;
+import org.energycompany.fixtures.TokenRefreshRequestFixtures;
+import org.energycompany.fixtures.TokenResponseFixtures;
+import org.energycompany.model.CustomResponse;
+import org.energycompany.model.auth.dto.request.TokenRefreshRequest;
+import org.energycompany.model.auth.dto.response.TokenResponse;
+import org.energycompany.service.RefreshTokenService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RefreshTokenAuthenticationControllerTest extends BaseIntegrationTest {
+
+    @MockitoBean
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldRefreshToken() throws Exception {
+
+        TokenRefreshRequest tokenRefreshRequest = TokenRefreshRequestFixtures.getTokenRefreshRequest();
+        TokenResponse tokenResponse = TokenResponseFixtures.getTokenResponse();
+
+        CustomResponse<TokenResponse> expectedResponse = CustomResponse.successOf(tokenResponse);
+
+        when(refreshTokenService.refreshToken(any(TokenRefreshRequest.class))).thenReturn(expectedResponse);
+
+        mockMvc.perform(post("/api/v1/authentication/customers/refresh-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenRefreshRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.response.accessToken").value("newAccessToken"));
+
+        verify(refreshTokenService, times(1)).refreshToken(any(TokenRefreshRequest.class));
+    }
+
+}

--- a/authentication-service/src/test/java/org/energycompany/controller/RegisterAuthenticationControllerTest.java
+++ b/authentication-service/src/test/java/org/energycompany/controller/RegisterAuthenticationControllerTest.java
@@ -1,0 +1,41 @@
+package org.energycompany.controller;
+
+import org.energycompany.common.BaseIntegrationTest;
+import org.energycompany.fixtures.RegisterRequestFixtures;
+import org.energycompany.model.auth.dto.request.RegisterRequest;
+import org.energycompany.service.RegisterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RegisterAuthenticationControllerTest extends BaseIntegrationTest {
+
+    @MockitoBean
+    private RegisterService registerService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldInvokeRegisterCustomerService() throws Exception {
+
+        RegisterRequest registerRequest = RegisterRequestFixtures.getRegisterRequest();
+        mockMvc.perform(post("/api/v1/authentication/customers/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.httpStatus").value("OK"));
+
+        verify(registerService, times(1)).registerCustomer(any(RegisterRequest.class));
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/fixtures/CustomerFixtures.java
+++ b/authentication-service/src/test/java/org/energycompany/fixtures/CustomerFixtures.java
@@ -1,0 +1,23 @@
+package org.energycompany.fixtures;
+
+import org.energycompany.model.auth.Customer;
+import org.energycompany.model.auth.enums.CustomerStatus;
+import org.energycompany.model.auth.enums.CustomerType;
+
+import java.util.UUID;
+
+public class CustomerFixtures {
+
+    public static Customer getCustomer() {
+
+        return Customer.builder()
+                .id(UUID.randomUUID().toString())
+                .email("valid.email@example.com")
+                .firstName("John")
+                .lastName("Doe")
+                .userName("sample username")
+                .customerStatus(CustomerStatus.ACTIVE)
+                .customerType(CustomerType.CUSTOMER)
+                .build();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/fixtures/LoginRequestFixtures.java
+++ b/authentication-service/src/test/java/org/energycompany/fixtures/LoginRequestFixtures.java
@@ -1,0 +1,16 @@
+package org.energycompany.fixtures;
+
+import lombok.experimental.UtilityClass;
+import org.energycompany.model.auth.dto.request.LoginRequest;
+
+@UtilityClass
+public class LoginRequestFixtures {
+
+    public static LoginRequest getLoginRequest() {
+
+        return LoginRequest.builder()
+                .userName("sample username")
+                .password("validPassword123")
+                .build();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/fixtures/RegisterRequestFixtures.java
+++ b/authentication-service/src/test/java/org/energycompany/fixtures/RegisterRequestFixtures.java
@@ -1,0 +1,32 @@
+package org.energycompany.fixtures;
+
+import lombok.experimental.UtilityClass;
+import org.energycompany.model.auth.dto.request.RegisterRequest;
+
+@UtilityClass
+public class RegisterRequestFixtures {
+
+    public static RegisterRequest getRegisterRequest() {
+
+        return RegisterRequest.builder()
+                .email("valid.email@example.com")
+                .password("validPassword123")
+                .firstName("John")
+                .lastName("Doe")
+                .userName("sample-username")
+                .role("customer")
+                .build();
+    }
+
+    public static RegisterRequest getRegisterRequestWithInvalidEmail() {
+
+        return RegisterRequest.builder()
+                .email("invalid.email")
+                .password("short")
+                .firstName("")
+                .lastName("")
+                .userName("sample-username")
+                .role("")
+                .build();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/fixtures/TokenInvalidateRequestFixtures.java
+++ b/authentication-service/src/test/java/org/energycompany/fixtures/TokenInvalidateRequestFixtures.java
@@ -1,0 +1,14 @@
+package org.energycompany.fixtures;
+
+import org.energycompany.model.auth.dto.request.TokenInvalidateRequest;
+
+public class TokenInvalidateRequestFixtures {
+
+    public static TokenInvalidateRequest getTokenInvalidateRequest() {
+
+        return TokenInvalidateRequest.builder()
+                .accessToken("validAccessToken")
+                .refreshToken("validRefreshToken")
+                .build();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/fixtures/TokenRefreshRequestFixtures.java
+++ b/authentication-service/src/test/java/org/energycompany/fixtures/TokenRefreshRequestFixtures.java
@@ -1,0 +1,20 @@
+package org.energycompany.fixtures;
+
+import org.energycompany.model.auth.dto.request.TokenRefreshRequest;
+
+public class TokenRefreshRequestFixtures {
+
+    public static TokenRefreshRequest getTokenRefreshRequest() {
+
+        return TokenRefreshRequest.builder()
+                .refreshToken("validRefreshToken")
+                .build();
+    }
+
+    public static TokenRefreshRequest getInvalidTokenRefreshRequest() {
+
+        return TokenRefreshRequest.builder()
+                .refreshToken("invalidRefreshToken")
+                .build();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/fixtures/TokenResponseFixtures.java
+++ b/authentication-service/src/test/java/org/energycompany/fixtures/TokenResponseFixtures.java
@@ -1,0 +1,15 @@
+package org.energycompany.fixtures;
+
+import org.energycompany.model.auth.dto.response.TokenResponse;
+
+public class TokenResponseFixtures {
+
+    public static TokenResponse getTokenResponse() {
+
+        return TokenResponse.builder()
+                .accessToken("newAccessToken")
+                .accessTokenExpiresAt(System.currentTimeMillis() + 3600)
+                .refreshToken("newRefreshToken")
+                .build();
+    }
+}

--- a/authentication-service/src/test/java/org/energycompany/service/CustomerLoginServiceTest.java
+++ b/authentication-service/src/test/java/org/energycompany/service/CustomerLoginServiceTest.java
@@ -1,0 +1,68 @@
+package org.energycompany.service;
+
+import org.energycompany.common.AbstractBaseServiceTest;
+import org.energycompany.fixtures.LoginRequestFixtures;
+import org.energycompany.fixtures.TokenResponseFixtures;
+import org.energycompany.integration.customer.CustomerServiceClient;
+import org.energycompany.model.CustomResponse;
+import org.energycompany.model.auth.dto.request.LoginRequest;
+import org.energycompany.model.auth.dto.response.TokenResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CustomerLoginServiceTest extends AbstractBaseServiceTest {
+
+    @InjectMocks
+    private CustomerLoginService customerLoginService;
+
+    @Mock
+    private CustomerServiceClient customerServiceClient;
+
+    @Test
+    void shouldLogin_WhenValidLoginRequest_ReturnsTokenResponse() {
+
+        LoginRequest loginRequest = LoginRequestFixtures.getLoginRequest();
+        TokenResponse tokenResponse = TokenResponseFixtures.getTokenResponse();
+
+        CustomResponse<TokenResponse> customResponse = CustomResponse.successOf(tokenResponse);
+        when(customerServiceClient.loginUser(any(LoginRequest.class))).thenReturn(customResponse);
+
+        CustomResponse<TokenResponse> response = customerLoginService.login(loginRequest);
+
+        assertNotNull(response);
+        assertTrue(response.getIsSuccess());
+        assertEquals(HttpStatus.OK, response.getHttpStatus());
+        assertEquals(tokenResponse, response.getResponse());
+
+        verify(customerServiceClient, times(1)).loginUser(any(LoginRequest.class));
+
+    }
+
+    @Test
+    void shouldNotLogin_WhenInvalidLoginRequest_ReturnsErrorResponse() {
+
+        LoginRequest loginRequest = new LoginRequest();
+        CustomResponse<TokenResponse> errorResponse = CustomResponse.<TokenResponse>builder()
+                .httpStatus(HttpStatus.UNAUTHORIZED)
+                .isSuccess(false)
+                .build();
+
+        when(customerServiceClient.loginUser(any(LoginRequest.class))).thenReturn(errorResponse);
+
+        CustomResponse<TokenResponse> response = customerLoginService.login(loginRequest);
+
+        assertNotNull(response);
+        assertFalse(response.getIsSuccess());
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getHttpStatus());
+        assertNull(response.getResponse());
+
+        verify(customerServiceClient, times(1)).loginUser(any(LoginRequest.class));
+    }
+
+}

--- a/authentication-service/src/test/java/org/energycompany/service/CustomerRegisterServiceTest.java
+++ b/authentication-service/src/test/java/org/energycompany/service/CustomerRegisterServiceTest.java
@@ -1,0 +1,58 @@
+package org.energycompany.service;
+
+import org.energycompany.common.AbstractBaseServiceTest;
+import org.energycompany.fixtures.CustomerFixtures;
+import org.energycompany.fixtures.RegisterRequestFixtures;
+import org.energycompany.integration.customer.CustomerServiceClient;
+import org.energycompany.model.auth.Customer;
+import org.energycompany.model.auth.dto.request.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CustomerRegisterServiceTest extends AbstractBaseServiceTest {
+
+    @InjectMocks
+    private RegisterService registerService;
+
+    @Mock
+    private CustomerServiceClient customerServiceClient;
+
+    @Test
+    void shouldRegisterCustomer_WhenValidRegisterRequest_ReturnsCustomer() {
+
+        RegisterRequest registerRequest = RegisterRequestFixtures.getRegisterRequest();
+
+        Customer expectedCustomer = CustomerFixtures.getCustomer();
+
+        when(customerServiceClient.register(any(RegisterRequest.class)))
+                .thenReturn(ResponseEntity.ok(expectedCustomer));
+
+        Customer result = registerService.registerCustomer(registerRequest);
+
+        assertNotNull(result);
+        assertEquals(expectedCustomer, result);
+
+        verify(customerServiceClient, times(1)).register(any(RegisterRequest.class));
+    }
+
+    @Test
+    void shouldNotRegisterCustomer_WhenInvalidRegisterRequest_ReturnsNull() {
+
+        RegisterRequest registerRequest = RegisterRequestFixtures.getRegisterRequestWithInvalidEmail();
+
+        when(customerServiceClient.register(any(RegisterRequest.class)))
+                .thenReturn(ResponseEntity.badRequest().build());
+
+        Customer result = registerService.registerCustomer(registerRequest);
+        assertNull(result);
+
+        verify(customerServiceClient, times(1)).register(any(RegisterRequest.class));
+    }
+
+}

--- a/authentication-service/src/test/java/org/energycompany/service/LogoutServiceTest.java
+++ b/authentication-service/src/test/java/org/energycompany/service/LogoutServiceTest.java
@@ -1,0 +1,68 @@
+package org.energycompany.service;
+
+import org.energycompany.common.AbstractBaseServiceTest;
+import org.energycompany.fixtures.TokenInvalidateRequestFixtures;
+import org.energycompany.integration.customer.CustomerServiceClient;
+import org.energycompany.model.CustomResponse;
+import org.energycompany.model.auth.dto.request.TokenInvalidateRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class LogoutServiceTest extends AbstractBaseServiceTest {
+
+    @InjectMocks
+    private LogoutService logoutService;
+
+    @Mock
+    private CustomerServiceClient customerServiceClient;
+
+    @Test
+    void shouldLogout_WhenValidTokenInvalidateRequest_ReturnsSuccess() {
+
+        TokenInvalidateRequest tokenInvalidateRequest = TokenInvalidateRequestFixtures.getTokenInvalidateRequest();
+        CustomResponse<Void> expectedResponse = CustomResponse.<Void>builder()
+                .httpStatus(HttpStatus.OK)
+                .isSuccess(true)
+                .build();
+
+        when(customerServiceClient.logout(any(TokenInvalidateRequest.class)))
+                .thenReturn(expectedResponse);
+
+        CustomResponse<Void> result = logoutService.logout(tokenInvalidateRequest);
+
+        assertNotNull(result);
+        assertTrue(result.getIsSuccess());
+        assertEquals(HttpStatus.OK, result.getHttpStatus());
+
+        verify(customerServiceClient, times(1)).logout(any(TokenInvalidateRequest.class));
+
+    }
+
+    @Test
+    public void shouldLogout_WhenInvalidTokenInvalidateRequest_ReturnsErrorResponse() {
+
+        TokenInvalidateRequest tokenInvalidateRequest = TokenInvalidateRequestFixtures.getTokenInvalidateRequest();
+        CustomResponse<Void> errorResponse = CustomResponse.<Void>builder()
+                .httpStatus(HttpStatus.UNAUTHORIZED)
+                .isSuccess(false)
+                .build();
+
+        when(customerServiceClient.logout(any(TokenInvalidateRequest.class)))
+                .thenReturn(errorResponse);
+
+        CustomResponse<Void> result = logoutService.logout(tokenInvalidateRequest);
+
+        assertNotNull(result);
+        assertFalse(result.getIsSuccess());
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getHttpStatus());
+
+        verify(customerServiceClient, times(1)).logout(any(TokenInvalidateRequest.class));
+    }
+
+}

--- a/authentication-service/src/test/java/org/energycompany/service/RefreshTokenServiceTest.java
+++ b/authentication-service/src/test/java/org/energycompany/service/RefreshTokenServiceTest.java
@@ -1,0 +1,73 @@
+package org.energycompany.service;
+
+import org.energycompany.common.AbstractBaseServiceTest;
+import org.energycompany.fixtures.TokenRefreshRequestFixtures;
+import org.energycompany.fixtures.TokenResponseFixtures;
+import org.energycompany.integration.customer.CustomerServiceClient;
+import org.energycompany.model.CustomResponse;
+import org.energycompany.model.auth.dto.request.TokenRefreshRequest;
+import org.energycompany.model.auth.dto.response.TokenResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class RefreshTokenServiceTest extends AbstractBaseServiceTest {
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private CustomerServiceClient customerServiceClient;
+
+    @Test
+    void shouldRefreshToken_WhenValidTokenRefreshRequest_ReturnsSuccess() {
+
+        TokenRefreshRequest tokenRefreshRequest = TokenRefreshRequestFixtures.getTokenRefreshRequest();
+        TokenResponse tokenResponse = TokenResponseFixtures.getTokenResponse();
+
+        CustomResponse<TokenResponse> expectedResponse = CustomResponse.successOf(tokenResponse);
+
+        when(customerServiceClient.refreshToken(any(TokenRefreshRequest.class)))
+                .thenReturn(expectedResponse);
+
+        CustomResponse<TokenResponse> result = refreshTokenService.refreshToken(tokenRefreshRequest);
+
+        assertNotNull(result);
+        assertTrue(result.getIsSuccess());
+        assertEquals(HttpStatus.OK, result.getHttpStatus());
+        assertEquals(tokenResponse, result.getResponse());
+
+        verify(customerServiceClient, times(1)).refreshToken(any(TokenRefreshRequest.class));
+    }
+
+    @Test
+    void shouldRefreshToken_WhenInvalidTokenRefreshRequest_ReturnsErrorResponse() {
+
+        TokenRefreshRequest tokenRefreshRequest = TokenRefreshRequest.builder()
+                .refreshToken("invalidRefreshToken")
+                .build();
+
+        CustomResponse<TokenResponse> errorResponse = CustomResponse.<TokenResponse>builder()
+                .httpStatus(HttpStatus.UNAUTHORIZED)
+                .isSuccess(false)
+                .build();
+
+        when(customerServiceClient.refreshToken(any(TokenRefreshRequest.class)))
+                .thenReturn(errorResponse);
+
+        CustomResponse<TokenResponse> result = refreshTokenService.refreshToken(tokenRefreshRequest);
+
+        assertNotNull(result);
+        assertFalse(result.getIsSuccess());
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getHttpStatus());
+        assertNull(result.getResponse());
+
+        verify(customerServiceClient, times(1)).refreshToken(any(TokenRefreshRequest.class));
+    }
+
+}

--- a/authentication-service/src/test/resources/application-test.properties
+++ b/authentication-service/src/test/resources/application-test.properties
@@ -1,0 +1,3 @@
+
+eureka.client.enabled=false
+integration.customer-service.url=${CUSTOMER_SERVICE_URL:http://localhost:5007/}


### PR DESCRIPTION
- Added fixtures for request/response models and integrated WireMock for mocking external dependencies.
- Implemented unit and integration tests for authentication services, including login, registration, logout, and token refresh functionalities.