### PR TITLE
Add caching for Elering electric price retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive energy management system that connects customers with their ener
 
 ## 📊 Overview
 
-This platform provides customers with tools to monitor their energy usage, manage metering points, and access real-time energy pricing information. The system consists of multiple microservices for scalability and maintainability.
+This platform provides customers with tools to monitor their energy usage, manage metering points, and see energy pricing information. The system consists of multiple microservices for scalability and maintainability.
 
 ## 🏗️ Architecture
 

--- a/consumption/consumption-service/build.gradle
+++ b/consumption/consumption-service/build.gradle
@@ -22,6 +22,7 @@ dependencyManagement {
 }
 
 dependencies {
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -29,10 +30,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/consumption/consumption-service/src/main/java/org/energycompany/config/CacheConfig.java
+++ b/consumption/consumption-service/src/main/java/org/energycompany/config/CacheConfig.java
@@ -1,0 +1,28 @@
+package org.energycompany.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String ELERING_ELECTRIC_PRICES_CACHE = "electricPrices";
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(ELERING_ELECTRIC_PRICES_CACHE);
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(1, TimeUnit.HOURS)
+                .maximumSize(1000)
+                .recordStats());
+        return cacheManager;
+    }
+
+}

--- a/consumption/consumption-service/src/main/java/org/energycompany/service/EleringAdapterService.java
+++ b/consumption/consumption-service/src/main/java/org/energycompany/service/EleringAdapterService.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.energycompany.enums.ResolutionEnum;
 import org.energycompany.integration.elering.EleringAdapterClient;
 import org.energycompany.integration.elering.dto.EleringElectricPriceResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.List;
+
+import static org.energycompany.config.CacheConfig.ELERING_ELECTRIC_PRICES_CACHE;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,10 @@ public class EleringAdapterService {
 
     private final EleringAdapterClient eleringAdapterClient;
 
+    @Cacheable(
+            value = ELERING_ELECTRIC_PRICES_CACHE,
+            key = "#startDateTime.toString() + #endDateTime.toString() + #resolution.name()"
+    )
     public List<EleringElectricPriceResponse> getElectricPrices(
             Instant startDateTime,
             Instant endDateTime,


### PR DESCRIPTION
Introduce Caffeine-based caching to improve the performance of EleringAdapterService by reducing redundant API calls. Configured a cache manager with a 1-hour expiration policy and maximum size of 1000. Updated dependencies and documentation accordingly.